### PR TITLE
Avoid double download of deb packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
 # https://github.com/mumble-voip/mumble/blob/master/docs/dev/build-instructions/build_linux.md
 
-FROM ubuntu:21.10 as build
+FROM ubuntu:21.10 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
-ENV MUMBLE_VERSION=v1.4.230
+RUN apt-get update && apt-get install --no-install-recommends -y \
+	libcap2 \
+	libzeroc-ice3.7 \
+	'^libprotobuf[0-9]+$' \
+	'^libgrpc[0-9]+$' \
+	libgrpc++1 \
+	libavahi-compat-libdnssd1 \
+	libqt5core5a \
+	libqt5network5 \
+	libqt5sql5 \
+	libqt5sql5-mysql \
+	libqt5sql5-psql \
+	libqt5sql5-sqlite \
+	libqt5xml5 \
+	libqt5dbus5 \
+	ca-certificates \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+FROM base as build
+ARG DEBIAN_FRONTEND=noninteractive
+ARG MUMBLE_VERSION=v1.4.230
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   git cmake build-essential ca-certificates pkg-config \
@@ -37,8 +58,7 @@ RUN git checkout "$MUMBLE_VERSION" && git submodule update --init --recursive
 
 RUN cmake -Dclient=OFF -DCMAKE_BUILD_TYPE=Release .. && cmake --build . -j $(nproc)
 
-FROM ubuntu:21.10
-ARG DEBIAN_FRONTEND=noninteractive
+FROM base
 RUN adduser murmur
 
 COPY --from=build /mumble/build/mumble-server /usr/bin/mumble-server
@@ -48,25 +68,6 @@ COPY ./config /etc/murmur
 COPY ./docker-entrypoint.sh /
 
 RUN chown -R murmur:nogroup /etc/murmur/
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-	libcap2 \
-	libzeroc-ice3.7 \
-	'^libprotobuf[0-9]+$' \
-	'^libgrpc[0-9]+$' \
-	libgrpc++1 \
-	libavahi-compat-libdnssd1 \
-	libqt5core5a \
-	libqt5network5 \
-	libqt5sql5 \
-	libqt5sql5-mysql \
-	libqt5sql5-psql \
-	libqt5sql5-sqlite \
-	libqt5xml5 \
-	libqt5dbus5 \
-	ca-certificates \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
 
 EXPOSE 64738/tcp 64738/udp 50051
 USER murmur


### PR DESCRIPTION
35 of 37 packages that are installed to run the mumble-server are also
installed for building the binary. With installing them first these
packages are not downloaded and installed twice.