### PR TITLE
Simplify entrypoint script a little bit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,31 +76,29 @@ else
 	# Iterate over all environment variable key, value pairs and check if they match our naming scheme
 	####
 	while IFS='=' read -d '' -r var value; do
-		if [[ "$var" == "MUMBLE_CONFIG_"* ]]; then
-			uppercase_variable=${var/MUMBLE_CONFIG_/}
+		uppercase_variable=${var/MUMBLE_CONFIG_/}
 
-			# Remove underscores (to ensure that it doesn't matter whether the user
-			# uses e.g. MUMBLE_CONFIG_DB_BLA or MUMBLE_CONFIG_DBBLA)
-			uppercase_variable_no_underscores="${uppercase_variable//_/}"
-			found=false
+		# Remove underscores (to ensure that it doesn't matter whether the user
+		# uses e.g. MUMBLE_CONFIG_DB_BLA or MUMBLE_CONFIG_DBBLA)
+		uppercase_variable_no_underscores="${uppercase_variable//_/}"
+		found=false
 
-			for current_config in "${existing_config_options[@]}"; do
-				# convert to uppercase
-				upper_current_config=${current_config^^}
-				
-				if [ "$upper_current_config" = "$uppercase_variable" ] || [ "$upper_current_config" = "$uppercase_variable_no_underscores" ]; then
-					set_config "$current_config" "$value"
-					found=true
-					break
-				fi
-			done
+		for current_config in "${existing_config_options[@]}"; do
+			# convert to uppercase
+			upper_current_config=${current_config^^}
 
-			if [ "$found" = "false" ]; then
-				>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
-				exit 1
+			if [ "$upper_current_config" = "$uppercase_variable" ] || [ "$upper_current_config" = "$uppercase_variable_no_underscores" ]; then
+				set_config "$current_config" "$value"
+				found=true
+				break
 			fi
+		done
+
+		if [ "$found" = "false" ]; then
+			>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
+			exit 1
 		fi
-	done < <( printenv --null ) # Feeding it in like this, prevents the creation of a subshell for the while-loop
+	done < <( printenv --null | grep -az MUMBLE_CONFIG_ ) # Feeding it in like this, prevents the creation of a subshell for the while-loop
 
 	####
 	# Default settings (will apply only, if user hasn't specified the respective config options themselves)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-DATA_DIR="/data"
-BARE_BONES_CONFIG_FILE="/etc/mumble/bare_config.ini"
-CONFIG_FILE="${DATA_DIR}/mumble_server_config.ini"
+readonly DATA_DIR="/data"
+readonly BARE_BONES_CONFIG_FILE="/etc/mumble/bare_config.ini"
+readonly CONFIG_FILE="${DATA_DIR}/mumble_server_config.ini"
 
-server_invocation=( "${@}" )
+declare -a server_invocation=("${@}")
+declare -a existing_config_options
+declare -a used_configs
 
 array_contains() {
 	local array_expansion="$1[@]" seeking="$2"
@@ -43,9 +45,6 @@ if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
 	CONFIG_FILE="$MUMBLE_CUSTOM_CONFIG_FILE"
 else
 	echo -e "# Config file automatically generated from the MUMBLE_CONFIG_* environment variables\n" > "${CONFIG_FILE}"
-
-	used_configs=()
-	existing_config_options=()
 
 	# Compile list of configurations that exist in bare bones config
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ CONFIG_FILE="${DATA_DIR}/mumble_server_config.ini"
 # Grab the original command line that is supposed to start the Mumble server
 server_invocation=( "${@}" )
 
-array_contains () { 
+array_contains () {
 	local array="$1[@]"
 	local seeking=$2
 	local contained=false
@@ -35,16 +35,16 @@ set_config() {
 			apply_value=false
 		fi
 	fi
-    
+
     if [[  "$apply_value" = "true" ]]; then
         echo "Setting config \"$config_name\" to: '$config_value'"
         used_configs+=("$config_name")
-        
+
         # Append config to our on-the-fly-built config file
         echo "${config_name}=${config_value}" >> "$CONFIG_FILE"
     fi
 }
-    
+
 # Drop the user into a shell, if they so wish
 if [[ "$1" = "bash" ||  "$1" = "sh" ]]; then
     echo "Dropping into interactive BASH session"
@@ -62,7 +62,7 @@ else
 
 	used_configs=()
 	existing_config_options=()
-    
+
 	####
 	# Check what kind of configurations there exist in the bare bones config file
 	####

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,14 +29,14 @@ set_config() {
 	local apply_value=true
 
 	# Don't use default value if the user already set one
-	if [ "$is_default" = "true" ]; then
+	if [[ "$is_default" = "true" ]]; then
 		contained=$( array_contains used_configs "$config_name" )
 		if [[ "$contained" = "true" ]]; then
 			apply_value=false
 		fi
 	fi
     
-    if [ "$apply_value" = "true" ]; then
+    if [[  "$apply_value" = "true" ]]; then
         echo "Setting config \"$config_name\" to: '$config_value'"
         used_configs+=("$config_name")
         
@@ -46,12 +46,12 @@ set_config() {
 }
     
 # Drop the user into a shell, if they so wish
-if [ "$1" = "bash" ] || [ "$1" = "sh" ]; then
+if [[ "$1" = "bash" ||  "$1" = "sh" ]]; then
     echo "Dropping into interactive BASH session"
     exec "${@}"
 fi
 
-if [ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]; then
+if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
 	# Just use the config file specified by the user and don't bother assembling our own
 	echo "Using manually specified config file at $MUMBLE_CUSTOM_CONFIG_FILE"
 	echo "All MUMBLE_CONFIG variables will be ignored"
@@ -87,14 +87,14 @@ else
 			# convert to uppercase
 			upper_current_config=${current_config^^}
 
-			if [ "$upper_current_config" = "$uppercase_variable" ] || [ "$upper_current_config" = "$uppercase_variable_no_underscores" ]; then
+			if [[ "$upper_current_config" = "$uppercase_variable" || "$upper_current_config" = "$uppercase_variable_no_underscores" ]]; then
 				set_config "$current_config" "$value"
 				found=true
 				break
 			fi
 		done
 
-		if [ "$found" = "false" ]; then
+		if [[ "$found" = "false" ]]; then
 			>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
 			exit 1
 		fi
@@ -118,7 +118,7 @@ fi
 ####
 # Additionnal environement variables
 ####
-if [ -n "$MUMBLE_VERBOSE" ] && [ "$MUMBLE_VERBOSE" = true ]; then
+if [[ -n "$MUMBLE_VERBOSE" && "$MUMBLE_VERBOSE" = true ]]; then
     server_invocation+=( "-v" )
 fi
 
@@ -128,7 +128,7 @@ server_invocation+=( "-ini" "${CONFIG_FILE}")
 ####
 # Variable to change the superuser password
 ####
-if [ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]; then
+if [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
     "${server_invocation[@]}" -supw "$MUMBLE_SUPERUSER_PASSWORD"
     echo "Successfully configured superuser password"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,10 +85,11 @@ else
 	set_config "port" 64738 true
 	set_config "users" 100 true
 
-	# Add ICE section
-	echo -e "\n[Ice]" >> "$CONFIG_FILE"
-	echo "Ice.Warn.UnknownProperties=1" >> "$CONFIG_FILE"
-	echo "Ice.MessageSizeMax=65536" >> "$CONFIG_FILE"
+	{ # Add ICE section
+		echo -e "\n[Ice]"
+		echo "Ice.Warn.UnknownProperties=1"
+		echo "Ice.MessageSizeMax=65536"
+	} >> "$CONFIG_FILE"
 fi
 
 # Additional environment variables
@@ -107,7 +108,7 @@ echo "Running Mumble server as uid=$(id -u) gid=$(id -g)"
 echo "\"${DATA_DIR}\" has the following permissions set:"
 echo "  $( stat ${DATA_DIR} --printf='%A, owner: \"%U\" (UID: %u), group: \"%G\" (GID: %g)' )"
 
-echo "Command run to start the service : ${server_invocation[@]}"
+echo "Command run to start the service : ${server_invocation[*]}"
 echo "Starting..."
 
 exec "${server_invocation[@]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,10 +10,12 @@ readonly CONFIG_REGEX="^(\;|\#)?\ *([a-zA-Z_0-9]+)=.*"
 readarray -t existing_config_options < <(sed -En "s/$CONFIG_REGEX/\2/p" "$BARE_BONES_CONFIG_FILE")
 
 # Create an associative array for faster config option lookup
-declare -A config_from_uppercase
+declare -A option_for
 
 for config in "${existing_config_options[@]}"; do
-	config_from_uppercase["${config^^}"]="$config"
+	# Ignore underscores during lookup
+	no_underscores="${config//_/}"
+	option_for["${no_underscores^^}"]="$config"
 done
 
 # Grab the original command line that is supposed to start the Mumble server
@@ -63,7 +65,7 @@ else
 	while IFS='=' read -d '' -r var value; do
 		# Uppercase and remove underscores so MUMBLE_CONFIG_A_B == MUMBLE_CONFIG_AB
 		uppercase_variable="${var/MUMBLE_CONFIG_/}"
-		config_option="${config_from_uppercase[${uppercase_variable//_/}]}"
+		config_option="${option_for[${uppercase_variable//_/}]}"
 
 		if [[ -z "$config_option" ]]; then
 			>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,9 +31,7 @@ set_config() {
 	# Don't use default value if the user already set one
 	if [[ "$is_default" = "true" ]]; then
 		contained=$( array_contains used_configs "$config_name" )
-		if [[ "$contained" = "true" ]]; then
-			apply_value=false
-		fi
+		[[ "$contained" = "true" ]] && apply_value=false
 	fi
 
     if [[  "$apply_value" = "true" ]]; then
@@ -118,9 +116,7 @@ fi
 ####
 # Additionnal environement variables
 ####
-if [[ -n "$MUMBLE_VERBOSE" && "$MUMBLE_VERBOSE" = true ]]; then
-    server_invocation+=( "-v" )
-fi
+[[ "$MUMBLE_VERBOSE" = true ]] && server_invocation+=( "-v" )
 
 # Make sure the correct config file will be used
 server_invocation+=( "-ini" "${CONFIG_FILE}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,12 @@ set -e
 readonly DATA_DIR="/data"
 readonly BARE_BONES_CONFIG_FILE="/etc/mumble/bare_config.ini"
 readonly CONFIG_FILE="${DATA_DIR}/mumble_server_config.ini"
+readonly CONFIG_REGEX="^(\;|\#)?\ *([a-zA-Z_0-9]+)=.*"
+
+# Compile list of configuration options from the bare-bones config
+readarray -t existing_config_options < <(sed -En "s/$CONFIG_REGEX/\2/p" "$BARE_BONES_CONFIG_FILE")
 
 declare -a server_invocation=("${@}")
-declare -a existing_config_options
 declare -a used_configs
 
 array_contains() {
@@ -45,14 +48,6 @@ if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
 	CONFIG_FILE="$MUMBLE_CUSTOM_CONFIG_FILE"
 else
 	echo -e "# Config file automatically generated from the MUMBLE_CONFIG_* environment variables\n" > "${CONFIG_FILE}"
-
-	# Compile list of configurations that exist in bare bones config
-
-	while read -r line; do
-		if [[ "$line" =~ ^(\;|\#)?\ *([a-zA-Z_0-9]+)=.* ]]; then
-			existing_config_options+=("${BASH_REMATCH[2]}")
-		fi
-	done < "$BARE_BONES_CONFIG_FILE"
 
 	# Process settings through variables of format MUMBLE_CONFIG_*
 


### PR DESCRIPTION
Refactor the entrypoint script to make it more readable for programmers.

Since variables should be documented in the `README.md`, comments were removed
where I felt they were superfluous, and the ones that felt necessary to identify
sections of the script were shortened, if possible.

As there was an instance of Bash's extended builtin test command (`[[]]`), all
tests that were previously using the POSIX command were switched in favor of it.
The shebang mentions Bash, after all.

Another style choice was inlining a few if statements where possible, and even
using `return` instead of `echo` in `array_contains`. The functions were
shortened, one even "flattened".

Bash's `readonly` and `declare` were introduced.

A couple of items from the ShellCheck output were addressed in 7f3c2c1. The
relevant items are `SC2129` and `SC2145`.

Instead of an overarching `if` statement in the `while` loop that processes
config variables, `grep` was used in its input in 6b48b36.

Finally, trailing whitespace was removed, though this is frowned upon by many.
Thought I would, since there were only three instances of it.
