### PR TITLE
Add toggle to allow "unknown" settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,21 @@ You can specify these environment variables when starting the container using th
 $ docker run -e "MUMBLE_CONFIG_SERVER_PASSWORD=123"
 ```
 
+Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail. The root cause of this error is the fact that
+this setting is incorrectly registered in the Murmur server code. You can workaround this error by setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` 
+environment variable to true and spelling `<configName>` exactly as written in [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
+
 
 ### Additional variables
 
 The following _additional_ variables can be set for further server configuration:
 
-| Environment Variable        | Description                                                                                                                                  |
-|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MUMBLE_CUSTOM_CONFIG_FILE` | Specify a custom config file path - **all `MUMBLE_CONFIG_` variables are IGNORED** <br/>(it's best to use a path inside the volume `/data/`) |
-| `MUMBLE_SUPERUSER_PASSWORD` | Specifies the SuperUser (Admin) password for this server. If this is not given, a random password will be generated upon first startup.      |
-| `MUMBLE_VERBOSE`            | Set to `true` to enable verbose logging in the server                                                                                        |
+| Environment Variable             | Description                                                                                                                                  |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` | Set to `true` to force the container to accept unknown settings passed as a `MUMBLE_CONFIG_` variable (see note above).                      |
+| `MUMBLE_CUSTOM_CONFIG_FILE`      | Specify a custom config file path - **all `MUMBLE_CONFIG_` variables are IGNORED** <br/>(it's best to use a path inside the volume `/data/`) |
+| `MUMBLE_SUPERUSER_PASSWORD`      | Specifies the SuperUser (Admin) password for this server. If this is not given, a random password will be generated upon first startup.      |
+| `MUMBLE_VERBOSE`                 | Set to `true` to enable verbose logging in the server                                                                                        |
 
 
 ## Building the container

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following _additional_ variables can be set for further server configuration
 
 | Environment Variable             | Description                                                                                                                                  |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` | Set to `true` to force the container to accept unknown settings passed as a `MUMBLE_CONFIG_` variable (see note above).                      |
+| `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` | Set to `true` to force the container to accept unknown settings passed as a `MUMBLE_CONFIG_` variable (see note below).                      |
 | `MUMBLE_CUSTOM_CONFIG_FILE`      | Specify a custom config file path - **all `MUMBLE_CONFIG_` variables are IGNORED** <br/>(it's best to use a path inside the volume `/data/`) |
 | `MUMBLE_SUPERUSER_PASSWORD`      | Specifies the SuperUser (Admin) password for this server. If this is not given, a random password will be generated upon first startup.      |
 | `MUMBLE_VERBOSE`                 | Set to `true` to enable verbose logging in the server                                                                                        |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ docker run -e "MUMBLE_CONFIG_SERVER_PASSWORD=123"
 ```
 
 Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail. The root cause of this error is the fact that
-this setting is incorrectly registered in the Murmur server code. You can workaround this error by setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` 
+this setting is incorrectly registered in the Mumble server code. You can workaround this error by setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` 
 environment variable to true and spelling `<configName>` exactly as written in [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ docker run -e "MUMBLE_CONFIG_SERVER_PASSWORD=123"
 
 Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail. The root cause of this error is the fact that
 this setting is incorrectly registered in the Mumble server code. You can workaround this error by setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` 
-environment variable to true and spelling `<configName>` exactly as written in [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
+environment variable to `true` and spelling `<configName>` exactly as written in the [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
 
 
 ### Additional variables

--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ You can specify these environment variables when starting the container using th
 $ docker run -e "MUMBLE_CONFIG_SERVER_PASSWORD=123"
 ```
 
-Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail. The root cause of this error is the fact that
-this setting is incorrectly registered in the Mumble server code. You can workaround this error by setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` 
-environment variable to `true` and spelling `<configName>` exactly as written in the [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
-
 
 ### Additional variables
 
@@ -101,6 +97,19 @@ The following _additional_ variables can be set for further server configuration
 | `MUMBLE_CUSTOM_CONFIG_FILE`      | Specify a custom config file path - **all `MUMBLE_CONFIG_` variables are IGNORED** <br/>(it's best to use a path inside the volume `/data/`) |
 | `MUMBLE_SUPERUSER_PASSWORD`      | Specifies the SuperUser (Admin) password for this server. If this is not given, a random password will be generated upon first startup.      |
 | `MUMBLE_VERBOSE`                 | Set to `true` to enable verbose logging in the server                                                                                        |
+
+
+Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail with the following error. 
+
+
+```
+mumble-server  | [ERROR]: Unable to find config corresponding to variable "<configName>"
+mumble-server exited with code 1
+```
+
+The root cause of this error is the fact that this setting is incorrectly registered in the Mumble server code. You can workaround this error by 
+setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` environment variable to `true` and spelling `<configName>` exactly as written in the
+[Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
 
 
 ## Building the container

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,14 +70,14 @@ else
 
 		if [[ -z "$config_option" ]]; then
 			if [[ "$MUMBLE_ACCEPT_UNKNOWN_SETTINGS" = true ]]; then
-                        	echo "[WARNING]: Unable to find config corresponding to variable \"$var\". Make sure that it is correctly spelled, using it as-is"
+				echo "[WARNING]: Unable to find config corresponding to variable \"$var\". Make sure that it is correctly spelled, using it as-is"
 				set_config "$var" "$value"
-                	else
+			else
 				>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
 				exit 1
 			fi
 		else
-	                set_config "$config_option" "$value"
+			set_config "$config_option" "$value"
 		fi
 
 	done < <( printenv --null | sed -zn 's/^MUMBLE_CONFIG_//p' )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,11 +69,17 @@ else
 		config_option="${option_for[$(normalize_name "$var")]}"
 
 		if [[ -z "$config_option" ]]; then
-			>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
-			exit 1
+			if [[ "$MUMBLE_ACCEPT_UNKNOWN_SETTINGS" = true ]]; then
+                        	echo "[WARNING]: Unable to find config corresponding to variable \"$var\". Make sure that it is correctly spelled, using it as-is"
+				set_config "$var" "$value"
+                	else
+				>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
+				exit 1
+			fi
+		else
+	                set_config "$config_option" "$value"
 		fi
 
-		set_config "$config_option" "$value"
 	done < <( printenv --null | sed -zn 's/^MUMBLE_CONFIG_//p' )
 	# ^ Feeding it in like this, prevents the creation of a subshell for the while-loop
 


### PR DESCRIPTION
Rationale: while `/etc/mumble/bare_config.ini` should always be aligned with the options supported by a given version of mumble, unalignment may occur (for instance issue #13). 

This PR provides a workaround to minimize the impact of such unalignment in the future and allows to use the new settings while waiting for a fix in the upstream code and without having to externalise all settings to a config file.

Details:
- addition of a `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` environment variable
- if it is set to `true`, then `entrypoint.sh` accepts `MUMBLE_CONFIGURATION_*` settings which are not defined in bundled `/etc/mumble/bare_config.ini` file. The unknown `*` settings names are used as-is and a warning is echoed to std out.
- else the behavior remains the same as the current one, i.e. when an unknown setting is found, then an error is thrown and docker-compose exists.

