### PR TITLE
Add compatbility support for old murmur.sqlite db

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,6 +98,14 @@ else
 
 	# Apply default settings if they're missing
 
+	# Compatibilty with old DB filename
+	OLD_DB_FILE="${DATA_DIR}/murmur.sqlite"
+	if [[ -f "$OLD_DB_FILE" ]]; then
+		set_config "database" "$OLD_DB_FILE" true
+	else
+		set_config "database" "${DATA_DIR}/mumble-server.sqlite" true
+	fi
+
 	set_config "database" "${DATA_DIR}/mumble-server.sqlite" true
 	set_config "ice" "\"tcp -h 127.0.0.1 -p 6502\"" true
 	set_config "welcometext" "\"<br />Welcome to this server, running the official Mumble Docker image.<br />Enjoy your stay!<br />\"" true


### PR DESCRIPTION
Problem:
Since `mumble_server_config.ini` is recreated every time, users of the old database filename `murmur.sqlite` will have their existing database ignored by the new default configuration setting.

Solution:
If the old `murmur.sqlite` database file exists in `${DATA_DIR}`, use that as the database file.
This should cleanly support users of the old database. 

Alternatives:
We could also migrate users from the old database filename to the new.
(i.e.`mv "$OLD_DB_FILE" "${DATA_DIR}/mumble-server.sqlite"`)