### PR TITLE
feature: Allow loading config values from secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ You can specify these environment variables when starting the container using th
 $ docker run -e "MUMBLE_CONFIG_SERVER_PASSWORD=123"
 ```
 
+As an alternative to environment variables, docker or podman secrets can be used to read configuration options from files which follow the `MUMBLE_CONFIG_<config_name>` name pattern and are located in the `/run/secrets` directory at runtime. The same rules to naming environment variables apply to these files as well.
+
+Please consult the documentation of docker or podman on how to use secrets for further details.
+- [Docker (Swarm) Secrets](https://docs.docker.com/engine/swarm/secrets/)
+- Podman Secrets
+  - [podman run with secrets](https://docs.podman.io/en/latest/markdown/podman-run.1.html#secret-secret-opt-opt)
+  - [podman secret subcommand](https://docs.podman.io/en/latest/markdown/podman-secret.1.html)
+
+### Example: Running the container with secrets using podman
+To set the server password and superuser password using podman secrets, the following series of commands can be used:
+
+```bash
+# Create the secrets
+echo -n "secretserver" | podman secret create MUMBLE_CONFIG_SERVER_PASSWORD -
+echo -n "supassword" | podman secret create MUMBLE_SUPERUSER_PASSWORD -
+
+# Run the server with these secrets mounted
+podman run --detach \
+           --name mumble-server \
+           --publish 64738:64738/tcp \
+           --publish 64738:64738/udp \
+           --secret MUMBLE_CONFIG_SERVER_PASSWORD \
+           --secret MUMBLE_SUPERUSER_PASSWORD \
+           --volume ./data/mumble:/data \
+           --restart on-failure \
+           mumblevoip/mumble-server:<tag>
+```
 
 ### Additional variables
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,8 @@ if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
 	CONFIG_FILE="$MUMBLE_CUSTOM_CONFIG_FILE"
 else
 	# Ensures the config file is empty, starting from a clean slate
-	echo -e "# Config file automatically generated from the MUMBLE_CONFIG_* environment variables or secrets in /run/secrets/MUMBLE_CONFIG_* files\n" > "${CONFIG_FILE}"
+	echo -e "# Config file automatically generated from the MUMBLE_CONFIG_* environment variables" > "${CONFIG_FILE}"
+	echo -e "# or secrets in /run/secrets/MUMBLE_CONFIG_* files\n" >> "${CONFIG_FILE}"
 
 	# Process settings through variables of format MUMBLE_CONFIG_*
 
@@ -111,7 +112,7 @@ else
 		else
 			set_config "$config_option" "$(cat $secret_file)"
 		fi
-	done < <(ls /run/secrets | sed -n 's/^MUMBLE_CONFIG_//p')
+	done < <( ls /run/secrets | sed -n 's/^MUMBLE_CONFIG_//p' )
 
 	# Apply default settings if they're missing
 
@@ -147,10 +148,11 @@ fi
 server_invocation+=( "-ini" "${CONFIG_FILE}")
 
 if [[ -f /run/secrets/MUMBLE_SUPERUSER_PASSWORD ]]; then
-	#Variable to change the superuser password
-    "${server_invocation[@]}" -supw "$(cat /run/secrets/MUMBLE_SUPERUSER_PASSWORD)"
-    echo "Successfully configured superuser password from container secret"
-elif [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
+	MUMBLE_SUPERUSER_PASSWORD="$(cat /run/secrets/MUMBLE_SUPERUSER_PASSWORD)"
+    echo "Read superuser password from container secret"
+fi
+
+if [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
 	#Variable to change the superuser password
     "${server_invocation[@]}" -supw "$MUMBLE_SUPERUSER_PASSWORD"
     echo "Successfully configured superuser password"


### PR DESCRIPTION
This PR adds the ability to load configuration values (and the superuser password) from files mounted in `/run/secrets/MUMBLE_CONFIG_*`files. These are usually created by docker or podman secrets.


I implemented this for my personal use in response to reading issue #27 but decided optimizing it for the default mountpoint of podman secrets, which I tested it with. 

Any feedback is appreciated, I plan to add some documentation to the README before marking this PR as *Ready for Review*.

