### PR TITLE
feat: add support for Qt6-based builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,55 @@
 FROM ubuntu:22.04 as base
 
+ADD ./scripts/* /mumble/scripts/
+WORKDIR /mumble/scripts
+
 ARG DEBIAN_FRONTEND=noninteractive
+ARG MUMBLE_VERSION=latest
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
-	libcap2 \
-	libzeroc-ice3.7 \
-	'^libprotobuf[0-9]+$' \
-	libavahi-compat-libdnssd1 \
-	libqt5core5a \
-	libqt5network5 \
-	libqt5sql5 \
-	libqt5sql5-mysql \
-	libqt5sql5-psql \
-	libqt5sql5-sqlite \
-	libqt5xml5 \
-	libqt5dbus5 \
-	ca-certificates \
-	# Workaround for systems like CentOS 7 which won't load libQt5Core.so as expected:
-	# see also https://stackoverflow.com/a/68897099/
-	binutils \
-	&& find /lib* /usr/lib* -name 'libQt5Core.so.*' -exec strip --remove-section=.note.ABI-tag {} \; \
-	&& apt-get -y purge binutils \
-	# End of workaround
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+    libcap2 \
+    libzeroc-ice3.7 \
+    '^libprotobuf[0-9]+$' \
+    libavahi-compat-libdnssd1 \
+    ca-certificates \
+    && export QT_VERSION="$( /mumble/scripts/choose_qt_version.sh )" \
+    && /mumble/scripts/install_qt.sh \
+    # Workaround for systems like CentOS 7 which won't load libQt5Core.so as expected:
+    # see also https://stackoverflow.com/a/68897099/
+    binutils \
+    && find /lib* /usr/lib* -name 'libQt?Core.so.*' -exec strip --remove-section=.note.ABI-tag {} \; \
+    && apt-get -y purge binutils \
+    # End of workaround
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data \
+    && rm -Rf /scripts
 
 
 
 FROM base as build
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  git cmake build-essential ca-certificates pkg-config \
-  libssl-dev \
-  qtbase5-dev \
-  qttools5-dev \
-  qttools5-dev-tools \
-  libboost-dev \
-  libprotobuf-dev \
-  protobuf-compiler \
-  libprotoc-dev \
-  libcap-dev \
-  libxi-dev \
-  libavahi-compat-libdnssd-dev \
-  libzeroc-ice-dev \
-  python3 \
-  git \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
 ADD ./scripts/* /mumble/scripts/
 WORKDIR /mumble/repo
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git cmake build-essential ca-certificates pkg-config \
+    libssl-dev \
+    libboost-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libprotoc-dev \
+    libcap-dev \
+    libxi-dev \
+    libavahi-compat-libdnssd-dev \
+    libzeroc-ice-dev \
+    python3 \
+    git \
+    && export QT_VERSION="$( /mumble/scripts/choose_qt_version.sh )" \
+    && /mumble/scripts/install_qt_dev.sh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG MUMBLE_VERSION=latest
 ARG MUMBLE_BUILD_NUMBER=""
@@ -58,8 +58,9 @@ ARG MUMBLE_CMAKE_ARGS=""
 # Clone the repo, build it and finally copy the default server ini file. Since this file may be at different locations and Docker
 # doesn't support conditional copies, we have to ensure that regardless of where the file is located in the repo, it will end
 # up at a unique path in our build container to be copied further down.
-RUN /mumble/scripts/clone.sh && /mumble/scripts/build.sh \
-&& /mumble/scripts/copy_one_of.sh ./scripts/murmur.ini ./auxiliary_files/mumble-server.ini default_config.ini
+RUN /mumble/scripts/clone.sh \
+    && /mumble/scripts/build.sh \
+    && /mumble/scripts/copy_one_of.sh ./scripts/murmur.ini ./auxiliary_files/mumble-server.ini default_config.ini
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as base
+FROM ubuntu:24.04 as base
 
 ADD ./scripts/* /mumble/scripts/
 WORKDIR /mumble/scripts
@@ -8,7 +8,7 @@ ARG MUMBLE_VERSION=latest
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libcap2 \
-    libzeroc-ice3.7 \
+    libzeroc-ice3.7t64 \
     '^libprotobuf[0-9]+$' \
     libavahi-compat-libdnssd1 \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 as base
+FROM ubuntu:24.04 AS base
 
 ADD ./scripts/* /mumble/scripts/
 WORKDIR /mumble/scripts
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 
 
-FROM base as build
+FROM base AS build
 ARG DEBIAN_FRONTEND=noninteractive
 
 ADD ./scripts/* /mumble/scripts/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,6 +41,7 @@ cmake \
 	-Dtests=ON \
 	-Dwarnings-as-errors=OFF \
 	-Dzeroconf=OFF \
+	-DCMAKE_UNITY_BUILD=ON \
 	$MUMBLE_CMAKE_ARGS \
 	..
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,4 +47,6 @@ cmake \
 
 cmake --build . -j $(nproc)
 
-ctest --output-on-failure . -j $(nproc)
+TEST_TIMEOUT=600 # seconds
+export QTEST_FUNCTION_TIMEOUT="$(( $TEST_TIMEOUT * 1000 ))" # milliseconds
+ctest --timeout $TIMEOUT --output-on-failure . -j $(nproc)

--- a/scripts/choose_qt_version.sh
+++ b/scripts/choose_qt_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+case "${MUMBLE_VERSION}" in
+	v1.4.* )  ;& # fallthrough
+	1.4.*  )  ;& # fallthrough
+	v1.5.* )  ;& # fallthrough
+	1.5.*  )  QT_VERSION=5
+		;;
+	v1.6.* )  ;& # fallthrough
+	1.6.*  )  ;& # fallthrough
+	latest )  ;& # fallthrough
+	*      )  QT_VERSION=6
+		;;
+esac
+
+if [[ -z "$QT_VERSION" ]]; then
+	1>&2 echo "Error: unable to determine Qt version from MUMBLE_VERSION=$MUMBLE_VERSION"
+	exit 1
+fi
+
+echo -n "$QT_VERSION"

--- a/scripts/install_qt.sh
+++ b/scripts/install_qt.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+if [[ "$QT_VERSION" = 6 ]]; then
+	QT_PACKAGES=(\
+		libqt6core6 \
+		libqt6network6 \
+		libqt6sql6 \
+		libqt6sql6-mysql \
+		libqt6sql6-psql \
+		libqt6sql6-sqlite \
+		libqt6xml6 \
+		libqt6dbus6 \
+	)
+elif [[ "$QT_VERSION" = 5 ]]; then
+	QT_PACKAGES=(\
+		libqt5core5a \
+		libqt5network5 \
+		libqt5sql5 \
+		libqt5sql5-mysql \
+		libqt5sql5-psql \
+		libqt5sql5-sqlite \
+		libqt5xml5 \
+		libqt5dbus5 \
+	)
+else
+	1>&2 echo "Error, unknown Qt version: '$QT_VERSION'"
+	exit 1
+fi
+
+apt install --no-install-recommends -y "${QT_PACKAGES[@]}"

--- a/scripts/install_qt.sh
+++ b/scripts/install_qt.sh
@@ -5,25 +5,25 @@ set -x
 
 if [[ "$QT_VERSION" = 6 ]]; then
 	QT_PACKAGES=(\
-		libqt6core6 \
-		libqt6network6 \
-		libqt6sql6 \
+		libqt6core6t64 \
+		libqt6network6t64 \
+		libqt6sql6t64 \
 		libqt6sql6-mysql \
 		libqt6sql6-psql \
 		libqt6sql6-sqlite \
-		libqt6xml6 \
-		libqt6dbus6 \
+		libqt6xml6t64 \
+		libqt6dbus6t64 \
 	)
 elif [[ "$QT_VERSION" = 5 ]]; then
 	QT_PACKAGES=(\
-		libqt5core5a \
-		libqt5network5 \
-		libqt5sql5 \
+		libqt5core5t64 \
+		libqt5network5t64 \
+		libqt5sql5t64 \
 		libqt5sql5-mysql \
 		libqt5sql5-psql \
 		libqt5sql5-sqlite \
-		libqt5xml5 \
-		libqt5dbus5 \
+		libqt5xml5t64 \
+		libqt5dbus5t64 \
 	)
 else
 	1>&2 echo "Error, unknown Qt version: '$QT_VERSION'"

--- a/scripts/install_qt_dev.sh
+++ b/scripts/install_qt_dev.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+if [[ "$QT_VERSION" = 6 ]]; then
+	QT_PACKAGES=(\
+		qt6-base-dev \
+		qt6-tools-dev \
+		qt6-tools-dev-tools \
+		qt6-qpa-plugins \
+	)
+elif [[ "$QT_VERSION" = 5 ]]; then
+	QT_PACKAGES=(\
+		qtbase5-dev \
+		qttools5-dev \
+		qttools5-dev-tools
+	)
+else
+	1>&2 echo "Error, unknown Qt version: '$QT_VERSION'"
+	exit 1
+fi
+
+apt install --no-install-recommends -y "${QT_PACKAGES[@]}"


### PR DESCRIPTION
With Mumble moving to use Qt6 this container was no longer able to build recent versions successfully. This commit adds support for building Qt6-based version of mumble-server.