### PR TITLE
feat: add support for PUID and PGID environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,19 +62,18 @@ RUN /mumble/scripts/clone.sh \
     && /mumble/scripts/build.sh \
     && /mumble/scripts/copy_one_of.sh ./scripts/murmur.ini ./auxiliary_files/mumble-server.ini default_config.ini
 
+RUN git clone https://github.com/ncopa/su-exec.git /mumble/repo/su-exec \
+    && cd /mumble/repo/su-exec && make
+
 
 
 FROM base
-ARG MUMBLE_UID=10000
-ARG MUMBLE_GID=10000
-
-RUN groupadd --gid $MUMBLE_GID mumble && useradd --uid $MUMBLE_UID --gid $MUMBLE_GID mumble
 
 COPY --from=build /mumble/repo/build/mumble-server /usr/bin/mumble-server
 COPY --from=build /mumble/repo/default_config.ini /etc/mumble/bare_config.ini
+COPY --from=build --chmod=755 /mumble/repo/su-exec/su-exec /usr/local/bin/su-exec
 
-RUN mkdir -p /data && chown -R mumble:mumble /data && chown -R mumble:mumble /etc/mumble
-USER mumble
+
 EXPOSE 64738/tcp 64738/udp
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The following _additional_ variables can be set for further server configuration
 | Environment Variable             | Description                                                                                                                                  |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` | Set to `true` to force the container to accept unknown settings passed as a `MUMBLE_CONFIG_` variable (see note below).                      |
+| `MUMBLE_CHOWN_DATA`              | Set to `false` to skip taking ownership of `/data` and its contents.                                                                         |
 | `MUMBLE_CUSTOM_CONFIG_FILE`      | Specify a custom config file path - **all `MUMBLE_CONFIG_` variables are IGNORED** <br/>(it's best to use a path inside the volume `/data/`) |
 | `MUMBLE_SUPERUSER_PASSWORD`      | Specifies the SuperUser (Admin) password for this server. If this is not given, a random password will be generated upon first startup.      |
 | `MUMBLE_VERBOSE`                 | Set to `true` to enable verbose logging in the server                                                                                        |
@@ -164,9 +165,9 @@ process employed by this Docker image.
 
 ### Using a different UID/GID
 
-Additionally, it is possible to specify the UID and the GID of the `mumble` user that is used inside the container. These can be controlled by the
-`MUMBLE_UID` and `MUMBLE_GID` build variables respectively. This is intended to allow you to use the same UID and GID as your user on your host
-system, in order to cause minimal issues when accessing mounted volumes.
+You can use Docker-standard `PUID` and `PGID` environment variables to set the UID and GID you wish mumble-server to run as and who will own the 
+files in `/data`. The default is UID:GID 10000:10000. Unless the environment variable `MUMBLE_CHOWN_DATA` is set to `false` the container will 
+take ownership of `/data` and any of its contents at container launch.
 
 ### Using custom build options
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,8 +68,8 @@ set_config() {
 
 # Drop the user into a shell, if they so wish
 if [[ "$1" = "bash" ||  "$1" = "sh" ]]; then
-    echo "Dropping into interactive BASH session"
-    exec "${@}"
+	echo "Dropping into interactive BASH session"
+	exec "${@}"
 fi
 
 if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
@@ -153,13 +153,13 @@ server_invocation+=( "-ini" "${CONFIG_FILE}")
 
 if [[ -f /run/secrets/MUMBLE_SUPERUSER_PASSWORD ]]; then
 	MUMBLE_SUPERUSER_PASSWORD="$(cat /run/secrets/MUMBLE_SUPERUSER_PASSWORD)"
-    echo "Read superuser password from container secret"
+	echo "Read superuser password from container secret"
 fi
 
 if [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
 	#Variable to change the superuser password
-    "${server_invocation[@]}" -supw "$MUMBLE_SUPERUSER_PASSWORD"
-    echo "Successfully configured superuser password"
+	"${server_invocation[@]}" -supw "$MUMBLE_SUPERUSER_PASSWORD"
+	echo "Successfully configured superuser password"
 fi
 
 # Set privileges for /app but only if pid 1 user is root and we are dropping privileges.
@@ -179,7 +179,7 @@ echo "Starting..."
 
 # Drop privileges (when asked to) if root, otherwise run as current user
 if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]]; then
-    su-exec ${PUID}:${PGID} "${server_invocation[@]}"
+	su-exec ${PUID}:${PGID} "${server_invocation[@]}"
 else
-    exec "${server_invocation[@]}"
+	exec "${server_invocation[@]}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+export PUID=${PUID:-10000}
+export PGID=${PGID:-10000}
+MUMBLE_CHOWN_DATA=${MUMBLE_CHOWN_DATA:-true}
+
 readonly DATA_DIR="/data"
 readonly BARE_BONES_CONFIG_FILE="/etc/mumble/bare_config.ini"
 readonly CONFIG_REGEX="^(\;|\#)?\ *([a-zA-Z_0-9]+)=.*"
@@ -158,12 +162,24 @@ if [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
     echo "Successfully configured superuser password"
 fi
 
+# Set privileges for /app but only if pid 1 user is root and we are dropping privileges.
+# If container is run as an unprivileged user, it means owner already handled ownership setup on their own.
+# Running chown in that case (as non-root) will cause error
+if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]] && [[ "${MUMBLE_CHOWN_DATA}" = true ]]; then
+	chown -R ${PUID}:${PGID} /data
+fi
+
 # Show /data permissions, in case the user needs to match the mount point access
-echo "Running Mumble server as uid=$(id -u) gid=$(id -g)"
+echo "Running Mumble server as uid=${PUID} gid=${PGID}"
 echo "\"${DATA_DIR}\" has the following permissions set:"
 echo "  $( stat ${DATA_DIR} --printf='%A, owner: \"%U\" (UID: %u), group: \"%G\" (GID: %g)' )"
 
 echo "Command run to start the service : ${server_invocation[*]}"
 echo "Starting..."
 
-exec "${server_invocation[@]}"
+# Drop privileges (when asked to) if root, otherwise run as current user
+if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]]; then
+    su-exec ${PUID}:${PGID} "${server_invocation[@]}"
+else
+    exec "${server_invocation[@]}"
+fi


### PR DESCRIPTION
This commit removes the hardcoded MUMBLE_UID and MUMBLE_GID and instead adopts the commonly used PUID and PGID environment variables for setting the desired UID:GID for mumble-server to run as. For backwards-compatibility they still default to 10000:10000.

Also, a new variable `MUMBLE_CHOWN_DATA` is used to define whether to chown `/data` and its contents or not.

Fixes #34