### PR TITLE
fix: exec on su-exec call to remain PID 1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -179,7 +179,7 @@ echo "Starting..."
 
 # Drop privileges (when asked to) if root, otherwise run as current user
 if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]]; then
-	su-exec ${PUID}:${PGID} "${server_invocation[@]}"
+	exec su-exec ${PUID}:${PGID} "${server_invocation[@]}"
 else
 	exec "${server_invocation[@]}"
 fi


### PR DESCRIPTION
## Overview

Resolves issue that prevents mumble server from receiving signals, introduced in #50.

## Details

Noticed today in production that mumble didn't reload certificates on `USR1` signal, sent by an external script. After some digging I've found out that privileges are now dropped with `su-exec` binary. But because we're not `exec`-ing `su-exec` binary itself - it creates another child process in the container and `bash` remains PID 1, effectively blocking all signals sent by the container runtime from reaching `mumble-server`.

So this PR adds `exec` call to `su-exec` that fixes `SIGUSR1` handling and accidentally fixes graceful container stop (due to the same reason above).

## Demos

<details>
  <summary>Before the fix</summary>

  ![Screenshot 2025-03-11 022029](https://github.com/user-attachments/assets/757845dd-abab-48a2-91b3-7ade1bec6490)
</details>

<details>
  <summary>After the fix</summary>

  ![Screenshot 2025-03-11 022121](https://github.com/user-attachments/assets/2d3c252a-9b6f-45d5-a580-bbbe6f877cfc)
</details>