### PR TITLE
fix(build): use TEST_TIMEOUT for ctest --timeout

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -49,4 +49,4 @@ cmake --build . -j $(nproc)
 
 TEST_TIMEOUT=600 # seconds
 export QTEST_FUNCTION_TIMEOUT="$(( $TEST_TIMEOUT * 1000 ))" # milliseconds
-ctest --timeout $TIMEOUT --output-on-failure . -j $(nproc)
+ctest --timeout $TEST_TIMEOUT --output-on-failure . -j $(nproc)


### PR DESCRIPTION
## Summary
Use the correct variable for ctest’s timeout in `scripts/build.sh`.

## Problem
The ctest step used `--timeout $TIMEOUT`, but only `TEST_TIMEOUT` is defined (600 seconds). `$TIMEOUT` is unset, so ctest did not get the intended timeout.

## Change
- Use `$TEST_TIMEOUT` in the ctest command so the 600s timeout is applied.

## Testing
- Build and run tests locally; ctest should run with a 600s timeout per test.