### PR TITLE
FEAT: Allow integrated TLS certificate management using `lego`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,19 +71,24 @@ RUN /mumble/scripts/clone.sh \
 RUN git clone https://github.com/ncopa/su-exec.git /mumble/repo/su-exec \
     && cd /mumble/repo/su-exec && make
 
-
-
+FROM goacme/lego:latest AS lego
 FROM base
 
+COPY --from=lego /lego /usr/local/bin/lego
 COPY --from=build /mumble/repo/build/mumble-server /usr/bin/mumble-server
 COPY --from=build /mumble/repo/default_config.ini /etc/mumble/bare_config.ini
 COPY --from=build --chmod=755 /mumble/repo/su-exec/su-exec /usr/local/bin/su-exec
 
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    supervisor \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 64738/tcp 64738/udp
 COPY entrypoint.sh /entrypoint.sh
+COPY acme_install_cert.sh /usr/local/bin/acme_install_cert
+COPY acme_manage_cert.sh /usr/local/bin/acme_manage_cert
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 VOLUME ["/data"]
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/bin/mumble-server"]
-
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The following _additional_ variables can be set for further server configuration
 | `MUMBLE_VERBOSE`                 | Set to `true` to enable verbose logging in the server                                                                                        |
 
 
-Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail with the following error. 
+Note: In the unlikely case where a `<configName>` setting is unknown to the container, startup will fail with the following error.
 
 
 ```
@@ -155,7 +155,7 @@ mumble-server  | [ERROR]: Unable to find config corresponding to variable "<conf
 mumble-server exited with code 1
 ```
 
-The root cause of this error is the fact that this setting is incorrectly registered in the Mumble server code. You can workaround this error by 
+The root cause of this error is the fact that this setting is incorrectly registered in the Mumble server code. You can workaround this error by
 setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` environment variable to `true` and spelling `<configName>` exactly as written in the
 [Murmur.ini](https://wiki.mumble.info/wiki/Murmur.ini) documentation.
 
@@ -180,8 +180,8 @@ process employed by this Docker image.
 
 ### Using a different UID/GID
 
-You can use Docker-standard `PUID` and `PGID` environment variables to set the UID and GID you wish mumble-server to run as and who will own the 
-files in `/data`. The default is UID:GID 10000:10000. Unless the environment variable `MUMBLE_CHOWN_DATA` is set to `false` the container will 
+You can use Docker-standard `PUID` and `PGID` environment variables to set the UID and GID you wish mumble-server to run as and who will own the
+files in `/data`. The default is UID:GID 10000:10000. Unless the environment variable `MUMBLE_CHOWN_DATA` is set to `false` the container will
 take ownership of `/data` and any of its contents at container launch.
 
 ### Using custom build options
@@ -206,4 +206,3 @@ Got permission denied while trying to connect to the Docker daemon socket
 you most likely invoked `docker` as a non-root user. In order for that to be possible, you need to add yourself to the `docker` group on your system.
 See the [official docs](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) on this topic for further
 information.
-

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Please consult the documentation of docker or podman on how to use secrets for f
   - [podman run with secrets](https://docs.podman.io/en/latest/markdown/podman-run.1.html#secret-secret-opt-opt)
   - [podman secret subcommand](https://docs.podman.io/en/latest/markdown/podman-secret.1.html)
 
+### Automatic TLS Certificate Management
+
+The Mumble docker image contains the ACME client [lego](https://go-acme.github.io/lego/) which may be used to automatically issue, renew and reload trusted TLS certificates from Let's Encrypt and other ACME enabled CAs.
+In order to make use of this feature you have to mount a persistant volume to `/etc/acme` and set some environment variables:
+
+- `ACME_ACCOUNT_MAIL`: Will be used to register an account with the given ACME service.
+- `ACME_SERVER`: The API URL of the ACME service. Defaults to Let's Encrypt. You may set this for example to `https://acme-staging-v02.api.letsencrypt.org/directory` in order to use the staging environment.
+- `ACME_DOMAIN`: The domain of your Mumble server. The certificate will be ordered for this domain.
+- `ACME_HTTP`: Set this to any value to use the HTTP-01 challenge. You have to expose your Mumble server directly to the internet via port 80 (not 443!).
+- `ACME_DNS`: Set this to the name of a [DNS provider supported by `lego`](https://go-acme.github.io/lego/dns/index.html). You have to provide credentials for the DNS API as mentioned in the `lego` docs.
+- `ACME_DNS_RESOLVERS`: You may set this to a semicolon separated list of DNS servers to use for validation. Set this to your DNS providers servers if you experience slow validations.
+
+If you have special requirements you can set the `ACME_LEGO_CMD` variable to a full `lego` command to make use of all features of `lego`.
+If you do so, you may omit all other `ACME_*` variables, but have to set the same values in your `ACME_LEGO_CMD` manually.
+Please do not include the `run` or `renew` subcommands, as these will be appended by the certificate management script.
+
 ### Example: Running the container with secrets using podman
 To set the server password and superuser password using podman secrets, the following series of commands can be used:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Please consult the documentation of docker or podman on how to use secrets for f
 ### Automatic TLS Certificate Management
 
 The Mumble docker image contains the ACME client [lego](https://go-acme.github.io/lego/) which may be used to automatically issue, renew and reload trusted TLS certificates from Let's Encrypt and other ACME enabled CAs.
-In order to make use of this feature you have to mount a persistant volume to `/etc/acme` and set some environment variables:
+In order to make use of this feature you have to mount a persistent volume to `/etc/acme` and set some environment variables:
 
 - `ACME_ACCOUNT_MAIL`: Will be used to register an account with the given ACME service.
 - `ACME_SERVER`: The API URL of the ACME service. Defaults to Let's Encrypt. You may set this for example to `https://acme-staging-v02.api.letsencrypt.org/directory` in order to use the staging environment.

--- a/acme_install_cert.sh
+++ b/acme_install_cert.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+log()
+{
+	echo "[mumble-cert-manager] $*"
+}
+
+MUMBLE_CERT_DIR=/data/acme
+PUID=${PUID:-10000}
+PGID=${PGID:-10000}
+
+log "Installing new certificate to $MUMBLE_CERT_DIR"
+install --owner="$PUID" --group="$PGID" --mode=0644 "$LEGO_CERT_PATH" "$MUMBLE_CERT_DIR/mumble.crt"
+install --owner="$PUID" --group "$PGID" --mode=0640 "$LEGO_CERT_KEY_PATH" "$MUMBLE_CERT_DIR/mumble.key"
+
+mumble_pid="$(pidof mumble-server || true)"
+if [[ -n "$mumble_pid" ]]; then
+	log "Signaling mumble to reload the certificate"
+	kill -USR1 "$mumble_pid"
+else
+	log "Mumble does not seem to be running (yet), so no certificate reload signal is sent"
+fi

--- a/acme_manage_cert.sh
+++ b/acme_manage_cert.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+log()
+{
+	echo "[mumble-cert-manager] $*"
+}
+
+if [[ -z "$ACME_DOMAIN" && -z "$ACME_LEGO_CMD" ]]; then
+	log "No automatic cert management configured. Goodbye."
+	sleep infinity # We just let the script hang forever so that supervisord does not put it in a restart loop
+fi
+
+LEGO_DIR="/etc/acme"
+CERT_DIR="/data/acme"
+mkdir -p "$CERT_DIR"
+
+if [[ ! -d "$LEGO_DIR" ]]; then
+	>&2 log "[ERROR] '$LEGO_DIR' does not exist. Did you forget to mount a volume?"
+	exit 1
+fi
+
+# Build a lego command if the user did not provide one
+if [[ -n "$ACME_LEGO_CMD" ]]; then
+	LEGO_CMD="$ACME_LEGO_CMD"
+else
+	SERVER="${ACME_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+	DOMAIN="${ACME_DOMAIN}"
+	ACCOUNT_MAIL="${ACME_ACCOUNT_MAIL}"
+	if [[ -z "$ACCOUNT_MAIL" ]]; then
+		>&2 log "[ERROR] Variable ACME_ACCOUNT_MAIL is undefined"
+		exit 1
+	fi
+	LEGO_CMD=(lego --email "$ACCOUNT_MAIL" --domains "$DOMAIN" --server "$SERVER" --path "$LEGO_DIR" --accept-tos)
+
+	if [[ -n "$ACME_HTTP" ]]; then
+		LEGO_CMD+=(--http)
+	elif [[ -n "$ACME_DNS" ]]; then
+		LEGO_CMD+=(--dns "$ACME_DNS")
+		if [[ -n "$ACME_DNS_RESOLVERS" ]]; then
+			IFS=';' read -ra resolvers <<< "$ACME_DNS_RESOLVERS"
+			for resolver in "${resolvers[@]}"; do
+				LEGO_CMD+=(--dns.resolvers "$resolver")
+			done
+		fi
+	else
+		# TODO: TLS-ALPN challenge
+		>&2 log "[ERROR] No ACME method configured. Set ACME_HTTP for HTTP-01 challenge or set ACME_DNS to one of the providers listed here: https://go-acme.github.io/lego/dns/index.html"
+		exit 1
+	fi
+
+fi
+
+log "Issuing initial certificate for $DOMAIN. Mumble startup might be delayed"
+"${LEGO_CMD[@]}" run --run-hook acme_install_cert
+
+# Renewal loop
+while true; do
+	log "Checking renewal..."
+	"${LEGO_CMD[@]}" renew --renew-hook acme_install_cert
+
+	log "Sleeping 12h before renewal check..."
+	sleep $((60 * 60 * 12))
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+log() {
+	echo "[mumble] $*"
+}
+
 export PUID=${PUID:-10000}
 export PGID=${PGID:-10000}
 MUMBLE_CHOWN_DATA=${MUMBLE_CHOWN_DATA:-true}
@@ -28,16 +32,16 @@ declare -a used_configs
 
 server_version="$( "${server_invocation[@]}" --version | grep -o "[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+" )"
 if [[ -z "$server_version" ]]; then
-	>&2 echo "Failed at obtaining/parsing server version"
+	>&2 log "Failed at obtaining/parsing server version"
 	exit 1
 fi
 
-echo "Using Mumble server version ${server_version}"
+log "Using Mumble server version ${server_version}"
 
 # https://stackoverflow.com/a/5257398
 version_components=( ${server_version//./ } )
 if [[ ${#version_components[@]} -ne 3 ]]; then
-	>&2 echo "Server version doesn't have the expected number of components"
+	>&2 log "Server version doesn't have the expected number of components"
 fi
 
 if [[ ${version_components[0]} -gt 1 ]] || [[ ${version_components[1]} -gt 5 ]]; then
@@ -104,9 +108,9 @@ set_config() {
 	[[ "$apply_value" != true ]] && return 0
 
 	if array_contains "SENSITIVE_CONFIGS" "$config_name"; then
-		echo "Setting config \"$config_name\" to: *********"
+		log "Setting config \"$config_name\" to: *********"
 	else
-		echo "Setting config \"$config_name\" to: '$config_value'"
+		log "Setting config \"$config_name\" to: '$config_value'"
 	fi
 	used_configs+=("$config_name")
 
@@ -115,14 +119,14 @@ set_config() {
 }
 
 # Drop the user into a shell, if they so wish
-if [[ "$1" = "bash" ||  "$1" = "sh" ]]; then
-	echo "Dropping into interactive BASH session"
+if [[ "$1" = "bash" ||	"$1" = "sh" ]]; then
+	log "Dropping into interactive BASH session"
 	exec "${@}"
 fi
 
 if [[ -f "$MUMBLE_CUSTOM_CONFIG_FILE" ]]; then
-	echo "Using manually specified config file at $MUMBLE_CUSTOM_CONFIG_FILE"
-	echo "All MUMBLE_CONFIG variables will be ignored"
+	log "Using manually specified config file at $MUMBLE_CUSTOM_CONFIG_FILE"
+	log "All MUMBLE_CONFIG variables will be ignored"
 	CONFIG_FILE="$MUMBLE_CUSTOM_CONFIG_FILE"
 else
 	# Ensures the config file is empty, starting from a clean slate
@@ -136,10 +140,10 @@ else
 
 		if [[ -z "$config_option" ]]; then
 			if [[ "$MUMBLE_ACCEPT_UNKNOWN_SETTINGS" = true ]]; then
-				echo "[WARNING]: Unable to find config corresponding to variable \"$var\". Make sure that it is correctly spelled, using it as-is"
+				log "[WARNING]: Unable to find config corresponding to variable \"$var\". Make sure that it is correctly spelled, using it as-is"
 				set_config "$var" "$value"
 			else
-				>&2 echo "[ERROR]: Unable to find config corresponding to variable \"$var\""
+				>&2 log "[ERROR]: Unable to find config corresponding to variable \"$var\""
 				exit 1
 			fi
 		else
@@ -155,10 +159,10 @@ else
 		secret_file="/run/secrets/MUMBLE_CONFIG_$var"
 		if [[ -z "$config_option" ]]; then
 			if [[ "$MUMBLE_ACCEPT_UNKNOWN_SETTINGS" = true ]]; then
-				echo "[WARNING]: Unable to find config corresponding to container secret \"$secret_file\". Make sure that it is correctly spelled, using it as-is"
+				log "[WARNING]: Unable to find config corresponding to container secret \"$secret_file\". Make sure that it is correctly spelled, using it as-is"
 				set_config "$var" "$value"
 			else
-				>&2 echo "[ERROR]: Unable to find config corresponding to container secret \"$secret_file\""
+				>&2 log "[ERROR]: Unable to find config corresponding to container secret \"$secret_file\""
 				exit 1
 			fi
 		else
@@ -185,6 +189,14 @@ else
 	set_config "port" 64738 true
 	set_config "users" 100 true
 
+	if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" ]]; then
+		if array_contains "used_configs" "sslCert" || array_contains "used_configs" "sslKey"; then
+			log "[WARNING] Overwriting sslKey/sslCert config since automatic certificate management is enabled"
+		fi
+		set_config "sslCert" "/data/acme/mumble.crt" false
+		set_config "sslKey" "/data/acme/mumble.key" false
+	fi
+
 	{ # Add ICE section
 		echo -e "\n[Ice]"
 		echo "Ice.Warn.UnknownProperties=1"
@@ -201,13 +213,13 @@ server_invocation+=( "$( normalize_cli_arg "--ini" )" "${CONFIG_FILE}")
 
 if [[ -f /run/secrets/MUMBLE_SUPERUSER_PASSWORD ]]; then
 	MUMBLE_SUPERUSER_PASSWORD="$(cat /run/secrets/MUMBLE_SUPERUSER_PASSWORD)"
-	echo "Read superuser password from container secret"
+	log "Read superuser password from container secret"
 fi
 
 if [[ -n "${MUMBLE_SUPERUSER_PASSWORD}" ]]; then
 	#Variable to change the superuser password
 	"${server_invocation[@]}" "$( normalize_cli_arg "--set-su-pw" )" "$MUMBLE_SUPERUSER_PASSWORD"
-	echo "Successfully configured superuser password"
+	log "Successfully configured superuser password"
 fi
 
 # Set privileges for /app but only if pid 1 user is root and we are dropping privileges.
@@ -217,13 +229,20 @@ if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]] && [[ "${MUMBLE_CHOWN_DATA}"
 	chown -R ${PUID}:${PGID} /data
 fi
 
-# Show /data permissions, in case the user needs to match the mount point access
-echo "Running Mumble server as uid=${PUID} gid=${PGID}"
-echo "\"${DATA_DIR}\" has the following permissions set:"
-echo "  $( stat ${DATA_DIR} --printf='%A, owner: \"%U\" (UID: %u), group: \"%G\" (GID: %g)' )"
+if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" ]]; then
+	while [[ ! -f "/data/acme/mumble.crt" ]]; do
+		log "Waiting for '/data/acme/mumble.crt' to be created"
+		sleep 20
+	done
+fi
 
-echo "Command run to start the service : ${server_invocation[*]}"
-echo "Starting..."
+# Show /data permissions, in case the user needs to match the mount point access
+log "Running Mumble server as uid=${PUID} gid=${PGID}"
+log "\"${DATA_DIR}\" has the following permissions set:"
+log "  $( stat ${DATA_DIR} --printf='%A, owner: \"%U\" (UID: %u), group: \"%G\" (GID: %g)' )"
+
+log "Command run to start the service : ${server_invocation[*]}"
+log "Starting..."
 
 # Drop privileges (when asked to) if root, otherwise run as current user
 if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]]; then

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[program:acme]
+command=/usr/local/bin/acme_manage_cert
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:mumble]
+command=/entrypoint.sh "/usr/bin/mumble-server"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
This PR adds the ability to issue and renew TLS certificates via ACME. The ACME tool `lego` is added to the docker image. When configured via `ACME_*` environment variables this tool will issue and renew the certs and trigger mumble to reload the updated certificate. When the user does not configure ACME the script that handles this just sleeps forever.

I have used this command to test it: 

```
docker run --rm -it \
  -e ACME_DOMAIN=mumble.example.com \
  -e ACME_ACCOUNT_MAIL=me@example.com \
  -e ACME_DNS=hetzner \
  -e HETZNER_API_TOKEN=get_your_own \
  -e MUMBLE_CONFIG_SERVER_PASSWORD=123 \
  -p 64738:64738 \
  -v mumble_data:/data/ \
  -v mumble_acme:/etc/acme \
  imagename
```

Testing this can be inconvenient, as you need to either have an API enabled DNS provider or expose your mumble server via port 80 directly to the internet, which is possibly blocked by webservices.
