### PR TITLE
FIX: add support for lego v5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ In order to make use of this feature you have to mount a persistent volume to `/
 - `ACME_DNS`: Set this to the name of a [DNS provider supported by `lego`](https://go-acme.github.io/lego/dns/index.html). You have to provide credentials for the DNS API as mentioned in the `lego` docs.
 - `ACME_DNS_RESOLVERS`: You may set this to a semicolon separated list of DNS servers to use for validation. Set this to your DNS providers servers if you experience slow validations.
 
-If you have special requirements you can set the `ACME_LEGO_CMD` variable to a full `lego` command to make use of all features of `lego`.
+If you have special requirements you can set the `ACME_LEGO_ARGS` variable to make use of all features of `lego`.
+The contents of this variable will be appended to `lego run`.
 If you do so, you may omit all other `ACME_*` variables, but have to set the same values in your `ACME_LEGO_CMD` manually.
 Please do not include the `run` or `renew` subcommands, as these will be appended by the certificate management script.
 

--- a/acme_install_cert.sh
+++ b/acme_install_cert.sh
@@ -12,8 +12,8 @@ PUID=${PUID:-10000}
 PGID=${PGID:-10000}
 
 log "Installing new certificate to $MUMBLE_CERT_DIR"
-install --owner="$PUID" --group="$PGID" --mode=0644 "$LEGO_CERT_PATH" "$MUMBLE_CERT_DIR/mumble.crt"
-install --owner="$PUID" --group "$PGID" --mode=0640 "$LEGO_CERT_KEY_PATH" "$MUMBLE_CERT_DIR/mumble.key"
+install --owner="$PUID" --group="$PGID" --mode=0644 "$LEGO_HOOK_CERT_PATH" "$MUMBLE_CERT_DIR/mumble.crt"
+install --owner="$PUID" --group "$PGID" --mode=0640 "$LEGO_HOOK_CERT_KEY_PATH" "$MUMBLE_CERT_DIR/mumble.key"
 
 mumble_pid="$(pidof mumble-server || true)"
 if [[ -n "$mumble_pid" ]]; then

--- a/acme_manage_cert.sh
+++ b/acme_manage_cert.sh
@@ -7,8 +7,8 @@ log()
 	echo "[mumble-cert-manager] $*"
 }
 
-if [[ -z "$ACME_DOMAIN" && -z "$ACME_LEGO_CMD" ]]; then
-	log "No automatic cert management configured. Goodbye."
+if [[ -z "$ACME_DOMAIN" && -z "$ACME_LEGO_ARGS" ]]; then
+	log "No automatic certificate management configured. Goodbye."
 	sleep infinity # We just let the script hang forever so that supervisord does not put it in a restart loop
 fi
 
@@ -22,8 +22,8 @@ if [[ ! -d "$LEGO_DIR" ]]; then
 fi
 
 # Build a lego command if the user did not provide one
-if [[ -n "$ACME_LEGO_CMD" ]]; then
-	LEGO_CMD="$ACME_LEGO_CMD"
+if [[ -n "$ACME_LEGO_ARGS" ]]; then
+	LEGO_ARGS="$ACME_LEGO_ARGS"
 else
 	SERVER="${ACME_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 	DOMAIN="${ACME_DOMAIN}"
@@ -32,16 +32,16 @@ else
 		>&2 log "[ERROR] Variable ACME_ACCOUNT_MAIL is undefined"
 		exit 1
 	fi
-	LEGO_CMD=(lego --email "$ACCOUNT_MAIL" --domains "$DOMAIN" --server "$SERVER" --path "$LEGO_DIR" --accept-tos)
+	LEGO_ARGS=(--email "$ACCOUNT_MAIL" --domains "$DOMAIN" --server "$SERVER" --path "$LEGO_DIR" --accept-tos)
 
 	if [[ -n "$ACME_HTTP" ]]; then
-		LEGO_CMD+=(--http)
+		LEGO_ARGS+=(--http)
 	elif [[ -n "$ACME_DNS" ]]; then
-		LEGO_CMD+=(--dns "$ACME_DNS")
+		LEGO_ARGS+=(--dns "$ACME_DNS")
 		if [[ -n "$ACME_DNS_RESOLVERS" ]]; then
 			IFS=';' read -ra resolvers <<< "$ACME_DNS_RESOLVERS"
 			for resolver in "${resolvers[@]}"; do
-				LEGO_CMD+=(--dns.resolvers "$resolver")
+				LEGO_ARGS+=(--dns.resolvers "$resolver")
 			done
 		fi
 	else
@@ -49,16 +49,14 @@ else
 		>&2 log "[ERROR] No ACME method configured. Set ACME_HTTP for HTTP-01 challenge or set ACME_DNS to one of the providers listed here: https://go-acme.github.io/lego/dns/index.html"
 		exit 1
 	fi
-
 fi
 
-log "Issuing initial certificate for $DOMAIN. Mumble startup might be delayed"
-"${LEGO_CMD[@]}" run --run-hook acme_install_cert
+log "Mumble startup might be delayed on the initial certificate request"
 
 # Renewal loop
 while true; do
-	log "Checking renewal..."
-	"${LEGO_CMD[@]}" renew --renew-hook acme_install_cert
+	log "Trying to request/renew the TLS certificate"
+	lego run "${LEGO_ARGS[@]}" --deploy-hook acme_install_cert...
 
 	log "Sleeping 12h before renewal check..."
 	sleep $((60 * 60 * 12))


### PR DESCRIPTION
Unfortunately the `lego` project released a new major version soon after I introduced the program into the mumble docker image. The new major version made various changes to the CLI. This PR makes the ACME management scripts compatible with `lego` v5