### PR TITLE
Provide ACME enabled images under a special tag

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -58,20 +58,38 @@ jobs:
             - name: Make tags for registries
               run: |
                 TAG_ARRAY=()
+                TAG_ARRAY_ACME=()
                 for current in $PRE_TAGS; do
-                  TAG_ARRAY+=("mumblevoip/$current" "ghcr.io/mumble-voip/$current")
+                  TAG_ARRAY+=("mumblevoip/${current}" "ghcr.io/mumble-voip/${current}")
+                  TAG_ARRAY_ACME+=("mumblevoip/${current}-acme" "ghcr.io/mumble-voip/${current}-acme")
                 done
                 TAGS="$( IFS=","; echo "${TAG_ARRAY[*]}" )"
+                TAGS_ACME="$( IFS=","; echo "${TAG_ARRAY_ACME[*]}" )"
                 echo "TAGS=$TAGS" >> $GITHUB_ENV
+                echo "TAGS_ACME=$TAGS_ACME" >> $GITHUB_ENV
 
-            - name: Build and push
+            - name: Build and push (standard image)
               uses: docker/build-push-action@v7
               with:
                 context: .
+                target: mumble
                 platforms: ${{ inputs.platforms }}
                 push: ${{ inputs.publish }}
                 build-args: |
                     MUMBLE_VERSION=${{ inputs.mumble_version }}
                 tags: ${{ env.TAGS }}
+              env:
+                MUMBLE_VERSION: ${{ inputs.mumble_version }}
+
+            - name: Build and push (ACME image)
+              uses: docker/build-push-action@v7
+              with:
+                context: .
+                target: mumble-acme
+                platforms: ${{ inputs.platforms }}
+                push: ${{ inputs.publish }}
+                build-args: |
+                    MUMBLE_VERSION=${{ inputs.mumble_version }}
+                tags: ${{ env.TAGS_ACME }}
               env:
                 MUMBLE_VERSION: ${{ inputs.mumble_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,24 +71,33 @@ RUN /mumble/scripts/clone.sh \
 RUN git clone https://github.com/ncopa/su-exec.git /mumble/repo/su-exec \
     && cd /mumble/repo/su-exec && make
 
-FROM goacme/lego:latest AS lego
-FROM base
-
-COPY --from=lego /lego /usr/local/bin/lego
+FROM base AS mumble
+# Standard docker image with mumble as PID 1
 COPY --from=build /mumble/repo/build/mumble-server /usr/bin/mumble-server
 COPY --from=build /mumble/repo/default_config.ini /etc/mumble/bare_config.ini
 COPY --from=build --chmod=755 /mumble/repo/su-exec/su-exec /usr/local/bin/su-exec
 
+EXPOSE 64738/tcp 64738/udp
+COPY entrypoint.sh /entrypoint.sh
+
+VOLUME ["/data"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/bin/mumble-server"]
+
+FROM goacme/lego:latest AS lego
+# Import the docker image for ACME client lego to copy its main binary into the mumble image
+FROM mumble AS mumble-acme
+# Special docker image including an ACME client for automatic TLS certificate provisioning.
+# PID 1 is supervisord, which then launches mumble and the ACME scripts. Must be started as root!
+COPY --from=lego /lego /usr/local/bin/lego
 RUN apt-get update && apt-get install --no-install-recommends -y \
     supervisor \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-EXPOSE 64738/tcp 64738/udp
-COPY entrypoint.sh /entrypoint.sh
 COPY acme_install_cert.sh /usr/local/bin/acme_install_cert
 COPY acme_manage_cert.sh /usr/local/bin/acme_manage_cert
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-VOLUME ["/data"]
+# Unset parents entrypoint
+ENTRYPOINT []
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Please consult the documentation of docker or podman on how to use secrets for f
 
 ### Automatic TLS Certificate Management
 
-The Mumble docker image contains the ACME client [lego](https://go-acme.github.io/lego/) which may be used to automatically issue, renew and reload trusted TLS certificates from Let's Encrypt and other ACME enabled CAs.
+Any Mumble docker image has a variant that contains the `-acme` suffix (e.g. `latest-acme`).
+These docker images contain the ACME client [lego](https://go-acme.github.io/lego/) which may be used to automatically issue, renew and reload trusted TLS certificates from Let's Encrypt and other ACME enabled CAs.
 In order to make use of this feature you have to mount a persistent volume to `/etc/acme` and set some environment variables:
 
 - `ACME_ACCOUNT_MAIL`: Will be used to register an account with the given ACME service.
@@ -130,6 +131,12 @@ If you have special requirements you can set the `ACME_LEGO_ARGS` variable to ma
 The contents of this variable will be appended to `lego run`.
 If you do so, you may omit all other `ACME_*` variables, but have to set the same values in your `ACME_LEGO_CMD` manually.
 Please do not include the `run` or `renew` subcommands, as these will be appended by the certificate management script.
+
+#### Differences between the regular image and the `-acme` image
+
+The images containing the ACME client come with some additional restrictions compared to the regular image:
+- Mumble is not PID 1, because a process manager is added to run multiple processes in a single docker image. You cannot send signals to Mumble via `docker kill`.
+- You can only set a different UID/GID via specifying the `PUID`/`PGID` variables. It is not possible to start the image as a different user via the `docker run --user` flag. Note that privileges will be dropped prior to launching Mumble, so the server will _never_ run as `root`.
 
 ### Example: Running the container with secrets using podman
 To set the server password and superuser password using podman secrets, the following series of commands can be used:
@@ -181,16 +188,22 @@ setting the `MUMBLE_ACCEPT_UNKNOWN_SETTINGS` environment variable to `true` and 
 
 After having cloned this repository, you can just run
 ```bash
-$ docker build .
+$ docker build --target mumble .
 ```
 in order to build a Mumble server from the latest commit in the upstream [master branch](https://github.com/mumble-voip/mumble/commits/master).
 
 If you prefer to instead build a specific version of the Mumble server, you can use the `MUMBLE_VERSION` argument like this:
 ```bash
-$ docker build --build-arg MUMBLE_VERSION=v1.4.230 .
+$ docker build --target mumble --build-arg MUMBLE_VERSION=v1.4.230 .
 ```
 `MUMBLE_VERSION` can either be one of the [published tags](https://github.com/mumble-voip/mumble/tags) of the upstream repository or a commit hash of
 the respective commit to build.
+
+If you want to build a version of the docker image that supports automating certificate management via ACME, you have to specify another build target:
+
+```bash
+$ docker build --target mumble-acme .
+```
 
 Note that either way, only Mumble versions >= 1.4 can be built using this image. Mumble versions 1.3 and earlier are not compatible with the build
 process employed by this Docker image.

--- a/acme_manage_cert.sh
+++ b/acme_manage_cert.sh
@@ -56,7 +56,7 @@ log "Mumble startup might be delayed on the initial certificate request"
 # Renewal loop
 while true; do
 	log "Trying to request/renew the TLS certificate"
-	lego run "${LEGO_ARGS[@]}" --deploy-hook acme_install_cert...
+	lego run "${LEGO_ARGS[@]}" --deploy-hook acme_install_cert
 
 	log "Sleeping 12h before renewal check..."
 	sleep $((60 * 60 * 12))


### PR DESCRIPTION
Since introducing the ACME client into the mumble docker image comes with some inherent breaking changes, we now provide them as a special tag with the `-acme` suffix.

Any image is also built with the `-acme` suffix. Please note that the way this is implemented a simple `docker build .` will now produce the acme image. This is documented in the README.

Note: I have not tested the modified CI job as I am not able to so.