### PR TITLE
feat: add shorthand versions (v1.5, v1.6) to docker tags

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -49,11 +49,15 @@ jobs:
 
             - name: Configure target tags (with latest)
               if: ${{ inputs.update_latest }}
-              run: echo "PRE_TAGS=mumble-server:latest mumble-server:${{ inputs.mumble_version }} mumble-server:${{ inputs.mumble_version }}-${{ inputs.docker_version }}" >> $GITHUB_ENV
+              run: |
+                MUMBLE_VER="${{ inputs.mumble_version }}"
+                echo "PRE_TAGS=mumble-server:latest mumble-server:${MUMBLE_VER} mumble-server:${MUMBLE_VER%.*} mumble-server:${MUMBLE_VER}-${{ inputs.docker_version }}" >> $GITHUB_ENV
 
             - name: Configure target tags (without latest)
               if: ${{ ! inputs.update_latest }}
-              run: echo "PRE_TAGS=mumble-server:${{ inputs.mumble_version }} mumble-server:${{ inputs.mumble_version }}-${{ inputs.docker_version }}" >> $GITHUB_ENV
+              run: |
+                MUMBLE_VER="${{ inputs.mumble_version }}"
+                echo "PRE_TAGS=mumble-server:${MUMBLE_VER} mumble-server:${MUMBLE_VER%.*} mumble-server:${MUMBLE_VER}-${{ inputs.docker_version }}" >> $GITHUB_ENV
                 
             - name: Make tags for registries
               run: |


### PR DESCRIPTION
These changes make images available with their respective shorthand version (v1.6, v1.5). This allows people to track a specific branch of mumble with their images without pinning concrete minor versions while still not upgrading to versions that might introduce bigger or breaking changes.

Note that this assumes that no images for previous versions are ever re-built and pushed. It looked to me as that were never the case so this rather naive approach might be all that is needed.