### PR TITLE
Fix Docker secret handling and ACME env var mismatches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,11 @@ RUN /mumble/scripts/clone.sh \
     && /mumble/scripts/build.sh \
     && /mumble/scripts/copy_one_of.sh ./scripts/murmur.ini ./auxiliary_files/mumble-server.ini default_config.ini
 
+# Pin su-exec so the image cannot pick up an unexpected upstream HEAD.
+ARG SU_EXEC_COMMIT=89c016e6e08749d583efdeda04b9f73e1218e253
 RUN git clone https://github.com/ncopa/su-exec.git /mumble/repo/su-exec \
-    && cd /mumble/repo/su-exec && make
+    && git -C /mumble/repo/su-exec checkout --detach "${SU_EXEC_COMMIT}" \
+    && make -C /mumble/repo/su-exec
 
 FROM base AS mumble
 # Standard docker image with mumble as PID 1

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ In order to make use of this feature you have to mount a persistent volume to `/
 - `ACME_DNS`: Set this to the name of a [DNS provider supported by `lego`](https://go-acme.github.io/lego/dns/index.html). You have to provide credentials for the DNS API as mentioned in the `lego` docs.
 - `ACME_DNS_RESOLVERS`: You may set this to a semicolon separated list of DNS servers to use for validation. Set this to your DNS providers servers if you experience slow validations.
 
-If you have special requirements you can set the `ACME_LEGO_ARGS` variable to make use of all features of `lego`.
+If you have special requirements you can set the `ACME_LEGO_ARGS` variable (or its alias `ACME_LEGO_CMD`) to make use of all features of `lego`.
 The contents of this variable will be appended to `lego run`.
-If you do so, you may omit all other `ACME_*` variables, but have to set the same values in your `ACME_LEGO_CMD` manually.
+If you do so, you may omit all other `ACME_*` variables.
 Please do not include the `run` or `renew` subcommands, as these will be appended by the certificate management script.
 
 #### Differences between the regular image and the `-acme` image

--- a/acme_manage_cert.sh
+++ b/acme_manage_cert.sh
@@ -7,6 +7,13 @@ log()
 	echo "[mumble-cert-manager] $*"
 }
 
+# ACME_LEGO_CMD is documented as an alias for ACME_LEGO_ARGS (and is what
+# entrypoint.sh historically checked). Accept either so cert management and
+# Mumble startup stay in sync.
+if [[ -z "$ACME_LEGO_ARGS" && -n "$ACME_LEGO_CMD" ]]; then
+	ACME_LEGO_ARGS="$ACME_LEGO_CMD"
+fi
+
 if [[ -z "$ACME_DOMAIN" && -z "$ACME_LEGO_ARGS" ]]; then
 	log "No automatic certificate management configured. Goodbye."
 	sleep infinity # We just let the script hang forever so that supervisord does not put it in a restart loop
@@ -23,7 +30,10 @@ fi
 
 # Build a lego command if the user did not provide one
 if [[ -n "$ACME_LEGO_ARGS" ]]; then
-	LEGO_ARGS="$ACME_LEGO_ARGS"
+	# Word-split the user-supplied flag string into an argv array. Without this,
+	# `lego run "${LEGO_ARGS[@]}"` would pass the entire string as one argument.
+	# shellcheck disable=SC2206
+	LEGO_ARGS=($ACME_LEGO_ARGS)
 else
 	SERVER="${ACME_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 	DOMAIN="${ACME_DOMAIN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -157,6 +157,7 @@ else
 	while read -r var; do
 		config_option="${option_for[$(normalize_name "$var")]}"
 		secret_file="/run/secrets/MUMBLE_CONFIG_$var"
+		value="$(cat "$secret_file")"
 		if [[ -z "$config_option" ]]; then
 			if [[ "$MUMBLE_ACCEPT_UNKNOWN_SETTINGS" = true ]]; then
 				log "[WARNING]: Unable to find config corresponding to container secret \"$secret_file\". Make sure that it is correctly spelled, using it as-is"
@@ -166,7 +167,7 @@ else
 				exit 1
 			fi
 		else
-			set_config "$config_option" "$(cat $secret_file)"
+			set_config "$config_option" "$value"
 		fi
 	done < <( ls /run/secrets 2> /dev/null | sed -n 's/^MUMBLE_CONFIG_//p' )
 
@@ -189,7 +190,7 @@ else
 	set_config "port" 64738 true
 	set_config "users" 100 true
 
-	if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" ]]; then
+	if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" || -n "$ACME_LEGO_ARGS" ]]; then
 		if array_contains "used_configs" "sslCert" || array_contains "used_configs" "sslKey"; then
 			log "[WARNING] Overwriting sslKey/sslCert config since automatic certificate management is enabled"
 		fi
@@ -229,7 +230,7 @@ if [[ "$(id -u)" = "0" ]] && [[ "${PUID}" != "0" ]] && [[ "${MUMBLE_CHOWN_DATA}"
 	chown -R ${PUID}:${PGID} /data
 fi
 
-if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" ]]; then
+if [[ -n "$ACME_DOMAIN" || -n "$ACME_LEGO_CMD" || -n "$ACME_LEGO_ARGS" ]]; then
 	while [[ ! -f "/data/acme/mumble.crt" ]]; do
 		log "Waiting for '/data/acme/mumble.crt' to be created"
 		sleep 20


### PR DESCRIPTION
## Summary

- Docker secrets named `MUMBLE_CONFIG_*` never read the secret file when `MUMBLE_ACCEPT_UNKNOWN_SETTINGS=true`, so unknown options were written with an empty `$value`. The secret is now read first and applied in both paths.
- `ACME_LEGO_ARGS` and `ACME_LEGO_CMD` were checked inconsistently between `entrypoint.sh` and `acme_manage_cert.sh`. Users following the README could stall Mumble waiting for a cert that was never requested, or skip cert management. Both names are now accepted, and user-supplied lego flags are word-split into argv instead of being passed as a single argument.
- Pin `su-exec` to commit `89c016e` so image builds cannot pick up an unexpected upstream `HEAD`.

## Test plan

- [x] `bash -n entrypoint.sh acme_manage_cert.sh`
- [x] Isolated replay of the secret loop: a `MUMBLE_CONFIG_SERVERPASSWORD` file is actually read
- [x] Confirmed entrypoint checks `ACME_DOMAIN`, `ACME_LEGO_CMD`, and `ACME_LEGO_ARGS`
- [x] Confirmed `ACME_LEGO_CMD` aliases to `ACME_LEGO_ARGS` and is word-split
- Full `-acme` image build was not run here (needs Docker + Mumble compile)